### PR TITLE
Implémentation des scripts d'analyse

### DIFF
--- a/scripts/analyse_retours.py
+++ b/scripts/analyse_retours.py
@@ -1,9 +1,73 @@
-"""
-Analyse les retours des évaluateurs et génère un rapport d'impact.
-"""
+"""Analyse les retours des évaluateurs et génère un rapport d'impact."""
 
-def main():
-    print("analyse_retours.py lancé...")
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+LOG_FILE = Path("logs/analyse_retours.log")
+REPORT_FILE = Path("audit/impact_retours.csv")
+DATA_FILE = Path("data/retours.xlsx")
+
+
+def setup_logger() -> None:
+    """Configure file based logging."""
+    logging.basicConfig(
+        filename=LOG_FILE,
+        level=logging.INFO,
+        format="%(asctime)s - %(levelname)s - %(message)s",
+    )
+
+
+def compute_impact(filepath: Path) -> pd.DataFrame:
+    """Return feedback impact summary grouped by criticity level.
+
+    Parameters
+    ----------
+    filepath : Path
+        Excel file path containing evaluator feedback.
+
+    Returns
+    -------
+    pd.DataFrame
+        DataFrame with columns ``Criticite`` and ``Occurrences``.
+    """
+    df = pd.read_excel(filepath, engine="openpyxl")
+
+    criticity_col = df.filter(regex="(?i)critic").columns[0]
+    counts = (
+        df[criticity_col].str.lower().value_counts().rename_axis("Criticite")
+    )
+    return counts.rename("Occurrences").reset_index()
+
+
+def main() -> None:
+    """Analyse feedback and export an impact report."""
+    setup_logger()
+
+    if not DATA_FILE.exists():
+        logging.error("Fichier %s introuvable", DATA_FILE)
+        sys.exit(1)
+
+    try:
+        report = compute_impact(DATA_FILE)
+    except Exception as exc:  # fallback for unexpected format
+        logging.exception("Erreur lors de l'analyse des retours: %s", exc)
+        sys.exit(1)
+
+    try:
+        REPORT_FILE.parent.mkdir(parents=True, exist_ok=True)
+        report.to_csv(REPORT_FILE, index=False)
+    except Exception as exc:
+        logging.exception("Erreur lors de l'ecriture du rapport: %s", exc)
+        sys.exit(1)
+
+    logging.info("Rapport d'impact genere: %s", REPORT_FILE)
+    sys.exit(0)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/gen_matrice_finale.py
+++ b/scripts/gen_matrice_finale.py
@@ -1,9 +1,77 @@
-"""
-Génère la matrice de conformité finale à partir des preuves validées.
-"""
+"""Generate the final compliance matrix from validated evidence."""
 
-def main():
-    print("gen_matrice_finale.py lancé...")
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+LOG_FILE = Path("logs/gen_matrice_finale.log")
+OUTPUT_FILE = Path("audit/matrice_finale.xlsx")
+EVIDENCE_FILE = Path("data/preuves.xlsx")
+
+
+def setup_logger() -> None:
+    """Configure logging to file."""
+    logging.basicConfig(
+        filename=LOG_FILE,
+        level=logging.INFO,
+        format="%(asctime)s - %(levelname)s - %(message)s",
+    )
+
+
+def generate_matrix(filepath: Path) -> pd.DataFrame:
+    """Return compliant evidence rows from the Excel file.
+
+    Parameters
+    ----------
+    filepath : Path
+        Path to the evidence Excel file.
+
+    Returns
+    -------
+    pd.DataFrame
+        Filtered DataFrame containing only valid entries.
+    """
+    df = pd.read_excel(filepath, engine="openpyxl")
+
+    applicability_col = df.filter(regex="(?i)applicab").columns[0]
+    design_col = df.filter(regex="(?i)preuve.*conception").columns[0]
+    test_col = df.filter(regex="(?i)preuve.*test").columns[0]
+
+    mask = (
+        df[applicability_col].str.lower() == "oui"
+    ) & df[design_col].notna() & df[test_col].notna()
+
+    return df.loc[mask]
+
+
+def main() -> None:
+    """Generate the final matrix and export it to ``OUTPUT_FILE``."""
+    setup_logger()
+
+    if not EVIDENCE_FILE.exists():
+        logging.error("Fichier %s introuvable", EVIDENCE_FILE)
+        sys.exit(1)
+
+    try:
+        matrix = generate_matrix(EVIDENCE_FILE)
+    except Exception as exc:  # fallback for unexpected format
+        logging.exception("Erreur lors du traitement du fichier: %s", exc)
+        sys.exit(1)
+
+    try:
+        OUTPUT_FILE.parent.mkdir(parents=True, exist_ok=True)
+        matrix.to_excel(OUTPUT_FILE, index=False)
+    except Exception as exc:
+        logging.exception("Erreur lors de l'ecriture du fichier: %s", exc)
+        sys.exit(1)
+
+    logging.info("Matrice finale géneree: %s", OUTPUT_FILE)
+    sys.exit(0)
+
 
 if __name__ == "__main__":
     main()

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -1,0 +1,30 @@
+import os, sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+import pandas as pd
+from pathlib import Path
+
+from scripts.gen_matrice_finale import generate_matrix
+from scripts.analyse_retours import compute_impact
+
+
+def test_generate_matrix(tmp_path: Path) -> None:
+    df = pd.DataFrame({
+        "Applicability": ["Oui", "Non", "Oui"],
+        "Preuve_conception": ["doc1", None, "doc2"],
+        "Preuve_test": ["test1", "test2", None],
+    })
+    file_path = tmp_path / "preuves.xlsx"
+    df.to_excel(file_path, index=False, engine="openpyxl")
+
+    result = generate_matrix(file_path)
+    assert len(result) == 1
+
+
+def test_compute_impact(tmp_path: Path) -> None:
+    df = pd.DataFrame({"Criticité": ["Élevée", "Faible", "Élevée"]})
+    file_path = tmp_path / "retours.xlsx"
+    df.to_excel(file_path, index=False, engine="openpyxl")
+
+    report = compute_impact(file_path)
+    assert report.loc[report["Criticite"] == "élevée", "Occurrences"].iat[0] == 2
+


### PR DESCRIPTION
## Summary
- implémenter `analyse_retours` pour produire un rapport d'impact
- implémenter `gen_matrice_finale` pour générer la matrice consolidée
- ajouter les tests unitaires associés

## Testing
- `ruff check scripts main.py`
- `ruff check mon_projet_codex/src`
- `ruff check tests`
- `pip install -r requirements.txt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6849e780fbc0832e9defaa11984c49e0