### PR TITLE
Fix workflow scripts and make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,11 @@
-.PHONY: all check_exigences check_mop check_preuves soumettre_dossier gerer_retours analyse_impact_retours synthese_retours
+.PHONY: all prepare_dirs check_exigences check_mop check_preuves \
+        soumettre_dossier gerer_retours analyse_impact_retours synthese_retours \
+        run lint test doc
 
-all: check_exigences check_mop check_preuves soumettre_dossier gerer_retours analyse_impact_retours synthese_retours
+all: prepare_dirs check_exigences check_mop check_preuves soumettre_dossier gerer_retours analyse_impact_retours synthese_retours
+
+prepare_dirs:
+	mkdir -p logs audit
 
 check_exigences:
 	@echo "=== Vérification des exigences ==="
@@ -29,3 +34,15 @@ analyse_impact_retours:
 synthese_retours:
 	@echo "=== Synthèse des retours par exigence ==="
 	python scripts/synthese_retours.py >> logs/synthese_retours.log 2>&1 || exit 1
+
+run:
+	python main.py
+
+lint:
+	ruff check .
+
+test:
+	pytest -q
+
+doc:
+	pdoc --html --output-dir docs main.py scripts

--- a/scripts/analyse_retours.py
+++ b/scripts/analyse_retours.py
@@ -15,6 +15,7 @@ DATA_FILE = Path("data/retours.xlsx")
 
 def setup_logger() -> None:
     """Configure file based logging."""
+    LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
     logging.basicConfig(
         filename=LOG_FILE,
         level=logging.INFO,

--- a/scripts/check_exigences.py
+++ b/scripts/check_exigences.py
@@ -1,15 +1,8 @@
-"""Correspond à l'étape `step1_check_exigences` définie dans `workflow_certif.yaml`.
+"""Vérifie la complétude des exigences applicables.
 
-Description YAML :
-  - id: step1_check_exigences
-  - description: Vérifie les exigences applicables et leur justification.
-  - input: data/exigences.xlsx
-  - output: audit/exigences_incompletes.csv
-
-Instructions Codex :
-→ Implémenter cette logique dans ce fichier.
-→ Utiliser du code clair, modulaire, robuste (pandas, pathlib, logging, etc.).
-→ Voir aussi `README.md` et `AGENTS.md` pour le contexte global.
+Ce script correspond à l'étape ``check_exigences`` du ``workflow_certif.yaml``.
+Il lit ``data/exigences.xlsx`` et exporte les lignes non conformes dans
+``audit/exigences_incompletes.csv``.
 """
 
 from __future__ import annotations
@@ -27,6 +20,7 @@ DATA_FILE = Path("data/exigences.xlsx")
 
 def setup_logger() -> None:
     """Configure logging to file."""
+    LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
     logging.basicConfig(
         filename=LOG_FILE,
         level=logging.INFO,
@@ -56,8 +50,11 @@ def main() -> None:
         sys.exit(1)
 
     if not invalid_rows.empty:
+        AUDIT_FILE.parent.mkdir(parents=True, exist_ok=True)
         invalid_rows.to_csv(AUDIT_FILE, index=False)
-        logging.warning("Exigences non conformes detectees: %d", len(invalid_rows))
+        logging.warning(
+            "Exigences non conformes detectees: %d", len(invalid_rows)
+        )
         sys.exit(1)
 
     logging.info("Aucune anomalie detectee")

--- a/scripts/check_mop.py
+++ b/scripts/check_mop.py
@@ -15,6 +15,7 @@ DATA_FILE = Path("data/mop.xlsx")
 
 def setup_logger() -> None:
     """Configure logging."""
+    LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
     logging.basicConfig(
         filename=LOG_FILE,
         level=logging.INFO,
@@ -44,6 +45,7 @@ def main() -> None:
         sys.exit(1)
 
     if not invalid_rows.empty:
+        AUDIT_FILE.parent.mkdir(parents=True, exist_ok=True)
         invalid_rows.to_csv(AUDIT_FILE, index=False)
         logging.warning("MOP manquants: %d", len(invalid_rows))
         sys.exit(1)

--- a/scripts/check_preuves.py
+++ b/scripts/check_preuves.py
@@ -27,6 +27,7 @@ DATA_FILE = Path("data/preuves.xlsx")
 
 def setup_logger() -> None:
     """Configure logging."""
+    LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
     logging.basicConfig(
         filename=LOG_FILE,
         level=logging.INFO,
@@ -59,6 +60,7 @@ def main() -> None:
         sys.exit(1)
 
     if not invalid_rows.empty:
+        AUDIT_FILE.parent.mkdir(parents=True, exist_ok=True)
         invalid_rows.to_csv(AUDIT_FILE, index=False)
         logging.warning("Preuves manquantes: %d", len(invalid_rows))
         sys.exit(1)

--- a/scripts/gen_matrice_finale.py
+++ b/scripts/gen_matrice_finale.py
@@ -28,6 +28,7 @@ EVIDENCE_FILE = Path("data/preuves.xlsx")
 
 def setup_logger() -> None:
     """Configure logging to file."""
+    LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
     logging.basicConfig(
         filename=LOG_FILE,
         level=logging.INFO,

--- a/scripts/gerer_retours.py
+++ b/scripts/gerer_retours.py
@@ -15,6 +15,7 @@ DATA_FILE = Path("data/retours.xlsx")
 
 def setup_logger() -> None:
     """Configure logging."""
+    LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
     logging.basicConfig(
         filename=LOG_FILE,
         level=logging.INFO,
@@ -44,6 +45,7 @@ def main() -> None:
         sys.exit(1)
 
     if not critiques.empty:
+        AUDIT_FILE.parent.mkdir(parents=True, exist_ok=True)
         critiques.to_csv(AUDIT_FILE, index=False)
         logging.warning("Retours critiques identifies: %d", len(critiques))
         sys.exit(1)

--- a/scripts/soumettre_dossier.py
+++ b/scripts/soumettre_dossier.py
@@ -14,6 +14,7 @@ DATA_DIR = Path("data")
 
 def setup_logger() -> None:
     """Configure logging."""
+    LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
     logging.basicConfig(
         filename=LOG_FILE,
         level=logging.INFO,
@@ -30,6 +31,7 @@ def main() -> None:
         sys.exit(1)
 
     try:
+        OUTPUT_ARCHIVE.parent.mkdir(parents=True, exist_ok=True)
         if OUTPUT_ARCHIVE.exists():
             OUTPUT_ARCHIVE.unlink()
         shutil.make_archive(OUTPUT_ARCHIVE.with_suffix(""), "zip", DATA_DIR)

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -1,4 +1,5 @@
-import os, sys
+import os
+import sys
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 import pandas as pd
 from pathlib import Path

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -10,4 +10,4 @@ from main import load_workflow
 def test_load_workflow() -> None:
     cfg = load_workflow(Path("workflow_certif.yaml"))
     assert isinstance(cfg, dict)
-    assert len(cfg.get("steps", [])) == 5
+    assert len(cfg.get("steps", [])) == 7


### PR DESCRIPTION
## Summary
- add missing analyse_retours script and package `scripts`
- guard folder creation in every script
- fix failing workflow test and lint errors
- extend Makefile with run/lint/test/doc targets

## Testing
- `pytest -q`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_6849efd08dc4832eaed13b3a1052aea7