### PR TITLE
Add unit tests for orchestrator and feedback scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,9 @@ lint:
 	ruff check .
 
 test:
-	pytest -q
+       pytest -q
+
+test_all: test
 
 doc:
 	pdoc --html --output-dir docs main.py scripts

--- a/tests/test_analyse_retours.py
+++ b/tests/test_analyse_retours.py
@@ -1,0 +1,54 @@
+"""Tests for the feedback impact analysis script."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import scripts.analyse_retours as ar
+
+
+def test_compute_impact_summary(tmp_path: Path) -> None:
+    """Ensure ``compute_impact`` aggregates criticity correctly."""
+    df = pd.DataFrame({"Criticité": ["Haute", "Basse", "Haute"]})
+    file_path = tmp_path / "retours.xlsx"
+    df.to_excel(file_path, index=False, engine="openpyxl")
+
+    report = ar.compute_impact(file_path)
+    assert report.loc[report["Criticite"] == "haute", "Occurrences"].iat[0] == 2
+    assert report.iloc[-1]["Criticite"] == "Score global"
+
+
+def test_main_creates_report(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """``main`` should create the CSV report and exit with code ``0``."""
+    df = pd.DataFrame({"Criticité": ["Haute"]})
+    input_file = tmp_path / "retours.xlsx"
+    df.to_excel(input_file, index=False, engine="openpyxl")
+    output_file = tmp_path / "impact.csv"
+    log_file = tmp_path / "log.log"
+
+    monkeypatch.setattr(ar, "DATA_FILE", input_file)
+    monkeypatch.setattr(ar, "REPORT_FILE", output_file)
+    monkeypatch.setattr(ar, "LOG_FILE", log_file)
+
+    with pytest.raises(SystemExit) as exc:
+        ar.main()
+    assert exc.value.code == 0
+    assert output_file.exists()
+
+
+def test_main_missing_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """``main`` exits with code ``1`` when the input file is absent."""
+    monkeypatch.setattr(ar, "DATA_FILE", tmp_path / "absent.xlsx")
+    monkeypatch.setattr(ar, "REPORT_FILE", tmp_path / "impact.csv")
+    monkeypatch.setattr(ar, "LOG_FILE", tmp_path / "log.log")
+
+    with pytest.raises(SystemExit) as exc:
+        ar.main()
+    assert exc.value.code == 1

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,62 @@
+"""Unit tests for the workflow orchestrator."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from main import run_step, main as run_main
+
+
+def _create_script(script_path: Path, exit_code: int = 0) -> Path:
+    """Create a temporary Python script that exits with ``exit_code``."""
+    script_path.write_text(f"import sys\nsys.exit({exit_code})\n", encoding="utf-8")
+    return script_path
+
+
+def test_run_step_success(tmp_path: Path) -> None:
+    """Verify ``run_step`` returns ``0`` for a successful script."""
+    script = _create_script(tmp_path / "ok.py", 0)
+    rc = run_step({"id": "ok", "script": str(script)})
+    assert rc == 0
+
+
+def test_run_step_missing_script() -> None:
+    """``run_step`` should succeed when no script is provided."""
+    rc = run_step({"id": "noop"})
+    assert rc == 0
+
+
+def test_main_success(tmp_path: Path) -> None:
+    """``main`` runs every step and returns normally when all succeed."""
+    script = _create_script(tmp_path / "ok.py", 0)
+    config: dict[str, list[dict[str, Any]]] = {"steps": [{"id": "ok", "script": str(script)}]}
+    yaml_file = tmp_path / "workflow.yaml"
+    yaml_file.write_text(yaml.dump(config), encoding="utf-8")
+
+    run_main(str(yaml_file))
+
+
+def test_main_failure(tmp_path: Path) -> None:
+    """``main`` exits with the failing step's return code."""
+    ok_script = _create_script(tmp_path / "ok.py", 0)
+    bad_script = _create_script(tmp_path / "bad.py", 1)
+    config = {
+        "steps": [
+            {"id": "ok", "script": str(ok_script)},
+            {"id": "bad", "script": str(bad_script)},
+        ]
+    }
+    yaml_file = tmp_path / "workflow.yaml"
+    yaml_file.write_text(yaml.dump(config), encoding="utf-8")
+
+    with pytest.raises(SystemExit) as exc:
+        run_main(str(yaml_file))
+    assert exc.value.code == 1

--- a/tests/test_synthese_retours.py
+++ b/tests/test_synthese_retours.py
@@ -1,0 +1,46 @@
+"""Tests for generating a synthesis workbook from evaluator feedback."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from scripts.synthese_retours import synthese_retours
+
+
+def test_synthese_retours_generate(tmp_path: Path) -> None:
+    """The Excel workbook should contain both expected sheets."""
+    df = pd.DataFrame({
+        "Exigence": ["REQ1", "REQ1", "REQ2"],
+        "Commentaire": ["C1", "C2", "C3"],
+        "Criticité": ["Haute", "Basse", "Moyenne"],
+    })
+    input_file = tmp_path / "retours.xlsx"
+    df.to_excel(input_file, index=False, engine="openpyxl")
+    output_file = tmp_path / "synthese.xlsx"
+
+    synthese_retours(input_file, output_file)
+
+    assert output_file.exists()
+    sheets = pd.read_excel(output_file, sheet_name=None, engine="openpyxl")
+    assert set(sheets.keys()) == {"Tous_Retours", "Synthèse"}
+    assert len(sheets["Tous_Retours"]) == 3
+    row = sheets["Synthèse"].loc[sheets["Synthèse"]["Exigence"] == "REQ1"].iloc[0]
+    assert row["Commentaire"] == "C1 | C2"
+
+
+def test_synthese_retours_missing_columns(tmp_path: Path) -> None:
+    """Missing expected columns must raise ``ValueError``."""
+    df = pd.DataFrame({"Exigence": ["REQ1"], "Comment": ["C"]})
+    input_file = tmp_path / "retours.xlsx"
+    df.to_excel(input_file, index=False, engine="openpyxl")
+    output_file = tmp_path / "out.xlsx"
+
+    with pytest.raises(ValueError):
+        synthese_retours(input_file, output_file)


### PR DESCRIPTION
## Summary
- cover main workflow with tests for run_step and main logic
- test analyse_retours main routine with temp files
- add tests for synthese_retours workbook generation
- expose `test_all` Makefile target for convenience

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849fa5af4c8832eaaeeaf79053d2571