### PR TITLE
Implement OOP workflow engine

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,8 @@
 
 Ce fichier documente les différents agents ou assistants logiques pouvant intervenir dans l’implémentation automatisée du workflow de certification CAF, tel que défini dans `workflow_certif.yaml`.
 
+Le dépôt expose désormais un moteur orienté objet dans `workflow_certif/` permettant de charger le YAML et d'exécuter les étapes sous forme de classes Python.
+
 ---
 
 ## 🔹 Agent Name: CertifFlowCodex

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Workflow Certification CAF
 
 This project automates document certification steps defined in `workflow_certif.yaml`.
+The code exposes an object-oriented engine located in `workflow_certif/`.
+Each YAML step is mapped to a class deriving from `EtapeWorkflow`.
 
 ## Requirements
 - Python 3.10+
@@ -15,6 +17,16 @@ pip install -r requirements.txt
 Execute the full workflow:
 ```bash
 make run
+```
+The object-oriented API can be used as follows:
+```python
+from pathlib import Path
+from workflow_certif import CertificationDossier, WorkflowCertifEngine
+
+dossier = CertificationDossier("CAF001", Path("data"))
+engine = WorkflowCertifEngine()
+engine.charger_workflow(Path("workflow_certif.yaml"))
+engine.lancer(dossier)
 ```
 Run code quality checks:
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = ["pandas", "openpyxl", "pyyaml"]
 run-certif = "main:main"
 
 [tool.setuptools]
-packages = ["scripts"]
+packages = ["scripts", "workflow_certif"]
 
 [build-system]
 requires = ["setuptools", "wheel"]

--- a/src/workflow_certif/__init__.py
+++ b/src/workflow_certif/__init__.py
@@ -1,0 +1,23 @@
+"""Object-oriented certification workflow package."""
+
+from .models import CertificationDossier
+from .engine import WorkflowCertifEngine
+from .steps import (
+    VerificationPreuves,
+    AnalyseRetours,
+    ValidationMOP,
+    SoumissionDossier,
+)
+from .reporting import RapportImpact
+from .logger import LoggerCertif
+
+__all__ = [
+    "CertificationDossier",
+    "WorkflowCertifEngine",
+    "VerificationPreuves",
+    "AnalyseRetours",
+    "ValidationMOP",
+    "SoumissionDossier",
+    "RapportImpact",
+    "LoggerCertif",
+]

--- a/src/workflow_certif/engine.py
+++ b/src/workflow_certif/engine.py
@@ -1,0 +1,52 @@
+"""Workflow engine orchestrating the certification steps."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List
+
+import yaml
+
+from .models import CertificationDossier
+from .steps import (
+    EtapeWorkflow,
+    VerificationPreuves,
+    AnalyseRetours,
+    ValidationMOP,
+    SoumissionDossier,
+    ScriptStep,
+)
+
+
+class WorkflowCertifEngine:
+    """Load and run certification steps defined in a YAML file."""
+
+    def __init__(self) -> None:
+        self.etapes: List[EtapeWorkflow] = []
+
+    def charger_workflow(self, yaml_path: Path) -> None:
+        """Populate ``self.etapes`` from ``yaml_path``."""
+        with yaml_path.open("r", encoding="utf-8") as fh:
+            config = yaml.safe_load(fh)
+        mapping = {
+            "check_preuves": VerificationPreuves,
+            "gerer_retours": AnalyseRetours,
+            "check_mop": ValidationMOP,
+            "soumettre_dossier": SoumissionDossier,
+        }
+        self.etapes = []
+        for step_cfg in config.get("steps", []):
+            step_cls = mapping.get(step_cfg["id"], ScriptStep)
+            script = Path(step_cfg.get("script", "")) if step_cfg.get("script") else None
+            self.etapes.append(step_cls(script))
+
+    def lancer(self, dossier: CertificationDossier) -> None:
+        """Run all loaded steps sequentially."""
+        for etape in self.etapes:
+            ok = etape.executer(dossier)
+            if not ok:
+                dossier.statut = "echec"
+                dossier.sauvegarder_statut()
+                raise RuntimeError("Étape échouée")
+        dossier.statut = "termine"
+        dossier.sauvegarder_statut()

--- a/src/workflow_certif/logger.py
+++ b/src/workflow_certif/logger.py
@@ -1,0 +1,29 @@
+"""Logging utilities for the certification workflow."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+
+class LoggerCertif:
+    """Simple wrapper around :mod:`logging` for workflow messages."""
+
+    def __init__(self, log_dir: Path | None = None) -> None:
+        log_dir = log_dir or Path("logs")
+        log_dir.mkdir(parents=True, exist_ok=True)
+        log_file = log_dir / "workflow.log"
+        logging.basicConfig(
+            filename=log_file,
+            level=logging.INFO,
+            format="%(asctime)s - %(levelname)s - %(message)s",
+        )
+        self._logger = logging.getLogger("workflow_certif")
+
+    def log_info(self, message: str) -> None:
+        """Log an informational ``message``."""
+        self._logger.info(message)
+
+    def log_error(self, message: str) -> None:
+        """Log an error ``message``."""
+        self._logger.error(message)

--- a/src/workflow_certif/models.py
+++ b/src/workflow_certif/models.py
@@ -1,0 +1,60 @@
+"""Data models for the certification workflow."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+from .reporting import RapportImpact
+from .logger import LoggerCertif
+
+
+@dataclass
+class CertificationDossier:
+    """Represent a certification dossier.
+
+    Parameters
+    ----------
+    id : str
+        Identifier of the dossier.
+    chemin_dossier : Path
+        Root directory containing the certification files.
+    statut : str
+        Current workflow status.
+    """
+
+    id: str
+    chemin_dossier: Path
+    statut: str = "en_preparation"
+    impact: RapportImpact | None = field(default=None, init=False)
+    logger: LoggerCertif = field(default_factory=LoggerCertif, init=False)
+
+    def charger_documents(self) -> None:
+        """Load documents for the dossier.
+
+        The implementation simply checks that the directory exists.
+        """
+        if not self.chemin_dossier.exists():
+            self.logger.log_error(f"Dossier introuvable: {self.chemin_dossier}")
+            raise FileNotFoundError(self.chemin_dossier)
+        self.logger.log_info(f"Chargement du dossier: {self.chemin_dossier}")
+
+    def sauvegarder_statut(self) -> None:
+        """Persist the workflow status."""
+        statut_file = self.chemin_dossier / "statut.txt"
+        try:
+            statut_file.write_text(self.statut, encoding="utf-8")
+        except OSError as exc:
+            self.logger.log_error(f"Erreur ecriture statut: {exc}")
+            raise
+        self.logger.log_info(f"Statut sauvegarde: {self.statut}")
+
+    def enregistrer_impact(self, df: pd.DataFrame) -> None:
+        """Store an impact report inside the dossier."""
+        self.impact = RapportImpact(df)
+        csv_path = self.chemin_dossier / "impact.csv"
+        self.impact.exporter_csv(csv_path)
+        self.logger.log_info(f"Rapport d'impact enregistre: {csv_path}")

--- a/src/workflow_certif/reporting.py
+++ b/src/workflow_certif/reporting.py
@@ -1,0 +1,24 @@
+"""Reporting helpers for the certification workflow."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import pandas as pd
+
+
+@dataclass
+class RapportImpact:
+    """Container for impact reports."""
+
+    contenu: pd.DataFrame = field(default_factory=pd.DataFrame)
+
+    def generer(self, df: pd.DataFrame) -> None:
+        """Load impact ``df`` into the report."""
+        self.contenu = df
+
+    def exporter_csv(self, path: Path) -> None:
+        """Export the report to ``path`` in CSV format."""
+        path.parent.mkdir(parents=True, exist_ok=True)
+        self.contenu.to_csv(path, index=False)

--- a/src/workflow_certif/steps.py
+++ b/src/workflow_certif/steps.py
@@ -1,0 +1,54 @@
+"""Workflow step implementations."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from abc import ABC, abstractmethod
+
+from .models import CertificationDossier
+from .logger import LoggerCertif
+
+
+class EtapeWorkflow(ABC):
+    """Base class for workflow steps."""
+
+    def __init__(self, script: Path | None = None) -> None:
+        self.script = script
+        self.logger = LoggerCertif()
+
+    @abstractmethod
+    def executer(self, dossier: CertificationDossier) -> bool:
+        """Run the step on ``dossier``."""
+        raise NotImplementedError
+
+
+class ScriptStep(EtapeWorkflow):
+    """Generic step executing an external Python script."""
+
+    def executer(self, dossier: CertificationDossier) -> bool:
+        if not self.script:
+            self.logger.log_info("Aucun script a executer")
+            return True
+        result = subprocess.run(["python", str(self.script)], capture_output=True, text=True)
+        if result.returncode != 0:
+            self.logger.log_error(result.stderr)
+        else:
+            self.logger.log_info(result.stdout)
+        return result.returncode == 0
+
+
+class VerificationPreuves(ScriptStep):
+    """Step verifying evidences."""
+
+
+class AnalyseRetours(ScriptStep):
+    """Step analysing evaluator feedback."""
+
+
+class ValidationMOP(ScriptStep):
+    """Step validating MOP presence."""
+
+
+class SoumissionDossier(ScriptStep):
+    """Step submitting the dossier."""

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+import os
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(__file__))
+sys.path.append(os.path.join(ROOT, "src"))
+sys.path.append(ROOT)
+
+from workflow_certif import CertificationDossier, WorkflowCertifEngine
+
+
+def test_engine_load_and_run(tmp_path: Path) -> None:
+    yaml_path = Path('workflow_certif.yaml')
+    engine = WorkflowCertifEngine()
+    engine.charger_workflow(yaml_path)
+    assert len(engine.etapes) == 5
+
+    dossier_dir = tmp_path / 'dossier'
+    dossier_dir.mkdir()
+    dossier = CertificationDossier('TEST', dossier_dir)
+    # run steps; they will likely fail due to missing scripts but should raise RuntimeError
+    try:
+        engine.lancer(dossier)
+    except RuntimeError:
+        assert dossier.statut == 'echec'
+    else:
+        assert dossier.statut == 'termine'

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+import os
+import sys
+import pandas as pd
+
+ROOT = os.path.dirname(os.path.dirname(__file__))
+sys.path.append(os.path.join(ROOT, "src"))
+sys.path.append(ROOT)
+
+from workflow_certif import CertificationDossier, RapportImpact
+
+
+def test_certification_dossier(tmp_path: Path) -> None:
+    dossier = CertificationDossier('ID', tmp_path)
+    dossier.charger_documents()
+    dossier.statut = 'ok'
+    dossier.sauvegarder_statut()
+    assert (tmp_path / 'statut.txt').read_text(encoding='utf-8') == 'ok'
+
+    df = pd.DataFrame({'A': [1]})
+    dossier.enregistrer_impact(df)
+    assert (tmp_path / 'impact.csv').exists()


### PR DESCRIPTION
## Summary
- create `workflow_certif` package with engine, models and step classes
- expose logging and reporting helpers
- document the new API in README
- mention the engine in `AGENTS.md`
- update `pyproject.toml` to include new package
- add unit tests for engine and models

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a68649ed0832eb5e00e376895452c