### PR TITLE
Refactor to workflow package with objective engine

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ synthese_retours:
 	python scripts/synthese_retours.py >> logs/synthese_retours.log 2>&1 || exit 1
 
 run:
-	python main.py
+        python main.py pipeline
 
 lint:
 	ruff check .
@@ -47,4 +47,4 @@ test:
 test_all: test
 
 doc:
-	pdoc --html --output-dir docs main.py scripts
+        pdoc --html --output-dir docs main.py scripts workflow

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Workflow Certification CAF
 
 This project automates document certification steps defined in `workflow_certif.yaml`.
-The code exposes an object-oriented engine located in `workflow_certif/`.
-Each YAML step is mapped to a class deriving from `EtapeWorkflow`.
+The code exposes an object-oriented engine located in `workflow/`.
+Each YAML step is mapped to a class deriving from `EtapeWorkflow` and can be chained dynamically.
 
 ## Requirements
 - Python 3.10+
@@ -18,10 +18,14 @@ Execute the full workflow:
 ```bash
 make run
 ```
+Or run a specific objective:
+```bash
+python main.py objectif Soumission_dossier_valide
+```
 The object-oriented API can be used as follows:
 ```python
 from pathlib import Path
-from workflow_certif import CertificationDossier, WorkflowCertifEngine
+from workflow import CertificationDossier, WorkflowCertifEngine
 
 dossier = CertificationDossier("CAF001", Path("data"))
 engine = WorkflowCertifEngine()

--- a/main.py
+++ b/main.py
@@ -1,86 +1,83 @@
-"""Main orchestrator for the certification workflow."""
+"""Command-line interface for the certification workflow."""
 
 from __future__ import annotations
 
-import subprocess
-import sys
+import argparse
 from pathlib import Path
+import subprocess
 
+from workflow import CertificationDossier, WorkflowCertifEngine
 import yaml
 
 
 def load_workflow(yaml_path: Path) -> dict:
-    """Load YAML configuration for the workflow.
-
-    Parameters
-    ----------
-    yaml_path : Path
-        Path to the workflow configuration file.
-
-    Returns
-    -------
-    dict
-        Parsed YAML configuration.
-    """
-    with yaml_path.open("r", encoding="utf-8") as f:
-        return yaml.safe_load(f)
+    """Return the parsed YAML configuration."""
+    with yaml_path.open("r", encoding="utf-8") as fh:
+        return yaml.safe_load(fh)
 
 
 def run_step(step: dict) -> int:
-    """Execute a workflow step via its Python script.
-
-    Parameters
-    ----------
-    step : dict
-        Step configuration containing the script path and identifier.
-
-    Returns
-    -------
-    int
-        Return code from the executed script.
-    """
+    """Execute a Python script defined in ``step``."""
     script = step.get("script")
     if not script:
-        print(f"⚠️  Aucun script défini pour l'étape {step['id']}")
         return 0
-
-    print(f"🔧 Étape : {step['id']}")
-    result = subprocess.run([sys.executable, script], capture_output=True, text=True)
-    print(result.stdout)
-    if result.stderr:
-        print(result.stderr)
+    result = subprocess.run(["python", script])
     return result.returncode
 
 
-def main(yaml_path: str) -> None:
-    """Run workflow steps sequentially.
+def run_pipeline(cfg: Path, dossier_id: str, dossier_path: Path) -> None:
+    """Run the workflow sequentially based on ``cfg``."""
+    engine = WorkflowCertifEngine()
+    engine.charger_workflow(cfg)
+    dossier = CertificationDossier(dossier_id, dossier_path)
+    engine.lancer(dossier)
 
-    Parameters
-    ----------
-    yaml_path : str
-        Path to the workflow configuration YAML file.
 
-    Returns
-    -------
-    None
-        Exits with status code of the last executed step.
-    """
-    config = load_workflow(Path(yaml_path))
+def run_objectif(
+    name: str, cfg: Path, objectifs_file: Path, dossier_id: str, dossier_path: Path
+) -> None:
+    """Run steps adaptively to reach ``name`` objective."""
+    engine = WorkflowCertifEngine()
+    engine.charger_workflow(cfg)
+    engine.charger_objectifs(objectifs_file)
+    dossier = CertificationDossier(dossier_id, dossier_path)
+    engine.atteindre_objectif(name, dossier)
+
+
+def run_main(yaml_file: str) -> None:
+    """Backward-compatible entry point used in tests."""
+    config = load_workflow(Path(yaml_file))
     steps = config.get("steps", [])
-
     for step in steps:
         rc = run_step(step)
         if rc != 0:
-            print(f"❌ Étape échouée: {step['id']}")
-            sys.exit(rc)
+            raise SystemExit(rc)
 
-    print("✅ Workflow terminé avec succès")
+
+def main() -> None:
+    """Entry point for the CLI."""
+    parser = argparse.ArgumentParser(description="Certification workflow")
+    sub = parser.add_subparsers(dest="mode", required=True)
+
+    p_pipeline = sub.add_parser("pipeline", help="Run pipeline from YAML")
+    p_pipeline.add_argument("--yaml", default="workflow_certif.yaml")
+    p_pipeline.add_argument("--dossier", default="CAF001")
+    p_pipeline.add_argument("--chemin", default="data")
+
+    p_obj = sub.add_parser("objectif", help="Run workflow to reach an objective")
+    p_obj.add_argument("name")
+    p_obj.add_argument("--yaml", default="workflow_certif.yaml")
+    p_obj.add_argument("--objectifs", default="objectifs.yaml")
+    p_obj.add_argument("--dossier", default="CAF001")
+    p_obj.add_argument("--chemin", default="data")
+
+    args = parser.parse_args()
+    chemin = Path(args.chemin)
+    if args.mode == "pipeline":
+        run_pipeline(Path(args.yaml), args.dossier, chemin)
+    else:
+        run_objectif(args.name, Path(args.yaml), Path(args.objectifs), args.dossier, chemin)
 
 
 if __name__ == "__main__":
-    import argparse
-
-    parser = argparse.ArgumentParser(description="Run certification workflow")
-    parser.add_argument("--yaml", default="workflow_certif.yaml", help="Path to configuration YAML")
-    args = parser.parse_args()
-    main(args.yaml)
+    main()

--- a/objectifs.yaml
+++ b/objectifs.yaml
@@ -1,0 +1,13 @@
+objectif_principal: Soumission_dossier_valide
+
+objectifs:
+  Soumission_dossier_valide:
+    description: Générer et soumettre un dossier complet de certification
+    preconditions:
+      - check_mop
+      - check_exigences
+      - check_preuves
+      - soumettre_dossier
+    conditions_succès:
+      - fichier: dossiers/soumission_finale.zip
+        existe: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = ["pandas", "openpyxl", "pyyaml"]
 run-certif = "main:main"
 
 [tool.setuptools]
-packages = ["scripts", "workflow_certif"]
+packages = ["scripts", "workflow"]
 
 [build-system]
 requires = ["setuptools", "wheel"]

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -3,10 +3,9 @@ import os
 import sys
 
 ROOT = os.path.dirname(os.path.dirname(__file__))
-sys.path.append(os.path.join(ROOT, "src"))
 sys.path.append(ROOT)
 
-from workflow_certif import CertificationDossier, WorkflowCertifEngine
+from workflow import CertificationDossier, WorkflowCertifEngine
 
 
 def test_engine_load_and_run(tmp_path: Path) -> None:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -12,7 +12,7 @@ import yaml
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
-from main import run_step, main as run_main
+from main import run_step, run_main
 
 
 def _create_script(script_path: Path, exit_code: int = 0) -> Path:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -4,10 +4,9 @@ import sys
 import pandas as pd
 
 ROOT = os.path.dirname(os.path.dirname(__file__))
-sys.path.append(os.path.join(ROOT, "src"))
 sys.path.append(ROOT)
 
-from workflow_certif import CertificationDossier, RapportImpact
+from workflow import CertificationDossier, RapportImpact
 
 
 def test_certification_dossier(tmp_path: Path) -> None:

--- a/workflow/__init__.py
+++ b/workflow/__init__.py
@@ -1,0 +1,27 @@
+"""Object-oriented certification workflow package."""
+
+from .models import CertificationDossier
+from .engine import WorkflowCertifEngine
+from .steps import (
+    CheckExigences,
+    CheckMOP,
+    CheckPreuves,
+    SoumettreDossier,
+    GererRetours,
+    AnalyseRetours,
+)
+from .reporting import RapportImpact
+from .logger import LoggerCertif
+
+__all__ = [
+    "CertificationDossier",
+    "WorkflowCertifEngine",
+    "CheckExigences",
+    "CheckMOP",
+    "CheckPreuves",
+    "SoumettreDossier",
+    "GererRetours",
+    "AnalyseRetours",
+    "RapportImpact",
+    "LoggerCertif",
+]

--- a/workflow/engine.py
+++ b/workflow/engine.py
@@ -1,0 +1,103 @@
+"""Workflow engine orchestrating the certification steps."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, List
+
+import yaml
+
+from .models import CertificationDossier
+from .steps import (
+    EtapeWorkflow,
+    CheckExigences,
+    CheckMOP,
+    CheckPreuves,
+    SoumettreDossier,
+    AnalyseRetours,
+    GererRetours,
+    ScriptStep,
+)
+
+
+class WorkflowCertifEngine:
+    """Load and run certification steps defined in a YAML file."""
+
+    def __init__(self) -> None:
+        self.etapes: List[EtapeWorkflow] = []
+        self.etapes_dict: dict[str, EtapeWorkflow] = {}
+        self.objectifs: dict[str, Any] = {}
+
+    def charger_workflow(self, yaml_path: Path) -> None:
+        """Populate ``self.etapes`` from ``yaml_path``."""
+        with yaml_path.open("r", encoding="utf-8") as fh:
+            config = yaml.safe_load(fh)
+        mapping = {
+            "check_exigences": CheckExigences,
+            "check_mop": CheckMOP,
+            "check_preuves": CheckPreuves,
+            "soumettre_dossier": SoumettreDossier,
+            "gerer_retours": GererRetours,
+            "analyse_retours": AnalyseRetours,
+        }
+        self.etapes = []
+        self.etapes_dict = {}
+        for step_cfg in config.get("steps", []):
+            step_cls = mapping.get(step_cfg["id"], ScriptStep)
+            script = Path(step_cfg.get("script", "")) if step_cfg.get("script") else None
+            instance = step_cls(script)
+            self.etapes.append(instance)
+            self.etapes_dict[step_cfg["id"]] = instance
+
+    def charger_objectifs(self, yaml_path: Path) -> None:
+        """Load objectives definition from ``yaml_path``."""
+        with yaml_path.open("r", encoding="utf-8") as fh:
+            self.objectifs = yaml.safe_load(fh)
+
+    def atteindre_objectif(self, nom: str, dossier: CertificationDossier) -> None:
+        """Execute steps required to reach ``nom``."""
+        obj = self.objectifs.get("objectifs", {}).get(nom)
+        if not obj:
+            raise ValueError(f"Objectif inconnu: {nom}")
+        steps = obj.get("preconditions", [])
+        for step_id in steps:
+            step = self.etapes_dict.get(step_id)
+            if not step:
+                continue
+            if not step.executer(dossier):
+                dossier.statut = "echec"
+                dossier.sauvegarder_statut()
+                raise RuntimeError(f"Étape échouée: {step_id}")
+        if self.verifier_conditions_succes(obj.get("conditions_succès", [])):
+            dossier.statut = "termine"
+        else:
+            dossier.statut = "incomplet"
+        dossier.sauvegarder_statut()
+
+    def verifier_conditions_succes(self, conditions: list[dict[str, Any]]) -> bool:
+        """Return ``True`` if all ``conditions`` are satisfied."""
+        for cond in conditions:
+            path = Path(cond.get("fichier", ""))
+            if cond.get("existe") and not path.exists():
+                return False
+        return True
+
+    def evaluer_progres(self, objectif: str) -> float:
+        """Return completion ratio for ``objectif``."""
+        obj = self.objectifs.get("objectifs", {}).get(objectif, {})
+        steps = obj.get("preconditions", [])
+        if not steps:
+            return 0.0
+        done = sum(1 for s in steps if s in self.etapes_dict)
+        return done / len(steps)
+
+    def lancer(self, dossier: CertificationDossier) -> None:
+        """Run all loaded steps sequentially."""
+        for etape in self.etapes:
+            ok = etape.executer(dossier)
+            if not ok:
+                dossier.statut = "echec"
+                dossier.sauvegarder_statut()
+                raise RuntimeError("Étape échouée")
+        dossier.statut = "termine"
+        dossier.sauvegarder_statut()

--- a/workflow/logger.py
+++ b/workflow/logger.py
@@ -1,0 +1,29 @@
+"""Logging utilities for the certification workflow."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+
+class LoggerCertif:
+    """Simple wrapper around :mod:`logging` for workflow messages."""
+
+    def __init__(self, log_dir: Path | None = None) -> None:
+        log_dir = log_dir or Path("logs")
+        log_dir.mkdir(parents=True, exist_ok=True)
+        log_file = log_dir / "workflow.log"
+        logging.basicConfig(
+            filename=log_file,
+            level=logging.INFO,
+            format="%(asctime)s - %(levelname)s - %(message)s",
+        )
+        self._logger = logging.getLogger("workflow_certif")
+
+    def log_info(self, message: str) -> None:
+        """Log an informational ``message``."""
+        self._logger.info(message)
+
+    def log_error(self, message: str) -> None:
+        """Log an error ``message``."""
+        self._logger.error(message)

--- a/workflow/models.py
+++ b/workflow/models.py
@@ -1,0 +1,60 @@
+"""Data models for the certification workflow."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+from .reporting import RapportImpact
+from .logger import LoggerCertif
+
+
+@dataclass
+class CertificationDossier:
+    """Represent a certification dossier.
+
+    Parameters
+    ----------
+    id : str
+        Identifier of the dossier.
+    chemin_dossier : Path
+        Root directory containing the certification files.
+    statut : str
+        Current workflow status.
+    """
+
+    id: str
+    chemin_dossier: Path
+    statut: str = "en_preparation"
+    impact: RapportImpact | None = field(default=None, init=False)
+    logger: LoggerCertif = field(default_factory=LoggerCertif, init=False)
+
+    def charger_documents(self) -> None:
+        """Load documents for the dossier.
+
+        The implementation simply checks that the directory exists.
+        """
+        if not self.chemin_dossier.exists():
+            self.logger.log_error(f"Dossier introuvable: {self.chemin_dossier}")
+            raise FileNotFoundError(self.chemin_dossier)
+        self.logger.log_info(f"Chargement du dossier: {self.chemin_dossier}")
+
+    def sauvegarder_statut(self) -> None:
+        """Persist the workflow status."""
+        statut_file = self.chemin_dossier / "statut.txt"
+        try:
+            statut_file.write_text(self.statut, encoding="utf-8")
+        except OSError as exc:
+            self.logger.log_error(f"Erreur ecriture statut: {exc}")
+            raise
+        self.logger.log_info(f"Statut sauvegarde: {self.statut}")
+
+    def enregistrer_impact(self, df: pd.DataFrame) -> None:
+        """Store an impact report inside the dossier."""
+        self.impact = RapportImpact(df)
+        csv_path = self.chemin_dossier / "impact.csv"
+        self.impact.exporter_csv(csv_path)
+        self.logger.log_info(f"Rapport d'impact enregistre: {csv_path}")

--- a/workflow/reporting.py
+++ b/workflow/reporting.py
@@ -1,0 +1,24 @@
+"""Reporting helpers for the certification workflow."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import pandas as pd
+
+
+@dataclass
+class RapportImpact:
+    """Container for impact reports."""
+
+    contenu: pd.DataFrame = field(default_factory=pd.DataFrame)
+
+    def generer(self, df: pd.DataFrame) -> None:
+        """Load impact ``df`` into the report."""
+        self.contenu = df
+
+    def exporter_csv(self, path: Path) -> None:
+        """Export the report to ``path`` in CSV format."""
+        path.parent.mkdir(parents=True, exist_ok=True)
+        self.contenu.to_csv(path, index=False)

--- a/workflow/steps.py
+++ b/workflow/steps.py
@@ -1,0 +1,62 @@
+"""Workflow step implementations."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from abc import ABC, abstractmethod
+
+from .models import CertificationDossier
+from .logger import LoggerCertif
+
+
+class EtapeWorkflow(ABC):
+    """Base class for workflow steps."""
+
+    def __init__(self, script: Path | None = None) -> None:
+        self.script = script
+        self.logger = LoggerCertif()
+
+    @abstractmethod
+    def executer(self, dossier: CertificationDossier) -> bool:
+        """Run the step on ``dossier``."""
+        raise NotImplementedError
+
+
+class ScriptStep(EtapeWorkflow):
+    """Generic step executing an external Python script."""
+
+    def executer(self, dossier: CertificationDossier) -> bool:
+        if not self.script:
+            self.logger.log_info("Aucun script a executer")
+            return True
+        result = subprocess.run(["python", str(self.script)], capture_output=True, text=True)
+        if result.returncode != 0:
+            self.logger.log_error(result.stderr)
+        else:
+            self.logger.log_info(result.stdout)
+        return result.returncode == 0
+
+
+class CheckPreuves(ScriptStep):
+    """Step verifying evidences."""
+
+
+class AnalyseRetours(ScriptStep):
+    """Step analysing evaluator feedback."""
+
+
+class CheckMOP(ScriptStep):
+    """Step validating MOP presence."""
+
+
+class SoumettreDossier(ScriptStep):
+    """Step submitting the dossier."""
+
+
+class CheckExigences(ScriptStep):
+    """Step verifying documentary requirements."""
+
+
+class GererRetours(ScriptStep):
+    """Step handling evaluator feedback."""


### PR DESCRIPTION
## Summary
- adopt a new `workflow/` package that implements the steps and engine
- allow execution oriented toward declared objectives via `objectifs.yaml`
- update CLI using argparse with `pipeline` and `objectif` modes
- revise Makefile and README accordingly
- adjust tests to use the new package

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a6c6174b8832e8174239c641f86a4